### PR TITLE
Strongly type theme colors

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,13 +1,7 @@
 import { css } from '@emotion/core';
 import styled, { CreateStyled } from '@emotion/styled';
 
-export type Theme = {
-  space: number[],
-  fontSizes: number[],
-  colors: Record<string, string>,
-};
-
-export const theme: Theme = {
+export const theme = {
   space: [0, 5, 15, 30],
   fontSizes: [14, 16, 20, 26, 32],
   colors: {
@@ -19,6 +13,8 @@ export const theme: Theme = {
     player3: '#8fd5a6',
   },
 };
+
+export type Theme = typeof theme;
 
 export const globalStyles = (theme: Theme) => css`
   *, *:before, *:after {


### PR DESCRIPTION
* Use theme shape as type spec
* Can enforce we only used valid colors

----

## On master this is possible
![image](https://user-images.githubusercontent.com/1716853/102337303-50f99b80-3fb8-11eb-8eb1-259fe190c68c.png)

## On this branch it's an error
![image](https://user-images.githubusercontent.com/1716853/102337566-a2a22600-3fb8-11eb-85df-1c88b24aadc8.png)


